### PR TITLE
Improved poaching detection

### DIFF
--- a/rkill.lic
+++ b/rkill.lic
@@ -720,12 +720,12 @@ group_hook = proc {|line|
 		@group_mutex.synchronize {
 			@current_group.delete $~[:name]
 		}
-	when /$The Symbol of Need begins to burn in your mind and an image appears before you of|$You peer (?:\w+) and see/
+	when /^The Symbol of Need begins to burn in your mind and an image appears before you of|^You peer (?:\w+) and see/
 		@is_peer = true
-	when /$Obvious exits:/
+	when /Obvious (exits|paths):/
 		if @is_peer
 			@is_peer = false
-		elsif Room.current.id != @current_room_id
+		elsif @current_room_id && Room.current.id != @current_room_id
 			@new_room = true
 			@current_room_id = Room.current.id
 		end

--- a/rkill.lic
+++ b/rkill.lic
@@ -56,12 +56,14 @@ end
 @new_room = true
 @poaching = true
 @is_peer = false
-@poach_targets = []
 
 def poaching?
 	#Test if someone in the room is unexpected, to avoid poaching.
 	#This respects room order, e.g. who was in the room first has hunting rights
 	#If that person(group) leaves, it is no longer considered poaching
+	if !@poach_targets
+		@poach_targets = []
+	end
 	if @new_room
 		@poach_targets = []
 		pcs = Set.new @core_group

--- a/rkill.lic
+++ b/rkill.lic
@@ -711,12 +711,12 @@ command_hook = proc { |line|
 #Procedure for processing people joining/leaving the group organically
 group_hook = proc {|line|
 	case line
-	when /$(?<name>\w+) joins (your|\w+'s) group.^/
+	when /^(?<name>\w+) joins (your|\w+'s) group.$/
 		#Add person to group
 		@group_mutex.synchronize {
 			@current_group.push $~[:name]
 		}
-	when /$(?<name>\w+) leaves (your|\w+'s) group.^/
+	when /^(?<name>\w+) leaves (your|\w+'s) group.$/
 		@group_mutex.synchronize {
 			@current_group.delete $~[:name]
 		}

--- a/rkill.lic
+++ b/rkill.lic
@@ -56,19 +56,36 @@ end
 @new_room = true
 @poaching = true
 @is_peer = false
+@poach_targets = []
 
 def poaching?
 	#Test if someone in the room is unexpected, to avoid poaching
 	#Get minimal list of names to care about
 	if @new_room
+		@poach_targets = []
 		pcs = Set.new @core_group
 		@group_mutex.synchronize {
 			pcs.merge @current_group
 		}
 		party_members = Regexp.new pcs.to_a.join("|")
 		#Also check disk names against party members
-		@poaching = GameObj.pcs.any? {|pc| pc.name !~ party_members} || GameObj.loot.any? {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
+		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		@poach_targets = strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect{|disk|
+			disk.name =~ /(?<name>\w+) disk/
+			$~[:name]}
+		@poaching = !@poach_targets.empty?
 		@new_room = false
+	else
+		old_strangers = Set.new @poach_targets
+		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
+		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		current_strangers = Set.new strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect{|disk|
+			disk.name =~ /(?<name>\w+) disk/
+			$~[:name]}
+		if (current_strangers & old_strangers).empty?
+			@poaching = false
+		end
 	end
 	@poaching
 end

--- a/rkill.lic
+++ b/rkill.lic
@@ -72,8 +72,8 @@ def poaching?
 		}
 		party_members = Regexp.new pcs.to_a.join("|"), Regexp::IGNORECASE
 		#Build list of PC's not recognized, and also check disk names against party members
-		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
-		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members} || []
+		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members} || []
 		#We need nouns for comparison
 		@poach_targets = strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
 			disk.name =~ /(?<name>\w+) disk/
@@ -83,8 +83,8 @@ def poaching?
 		@new_room = false
 	else
 		old_strangers = Set.new @poach_targets
-		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
-		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members} || []
+		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members} || []
 		current_strangers = Set.new strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
 			disk.name =~ /(?<name>\w+) disk/
 			$~[:name]

--- a/rkill.lic
+++ b/rkill.lic
@@ -52,16 +52,23 @@ end
 	@current_group = get_current_group
 }
 
+@new_room = true
+@poaching = true
+
 def poaching?
 	#Test if someone in the room is unexpected, to avoid poaching
 	#Get minimal list of names to care about
-	pcs = Set.new @core_group
-	@group_mutex.synchronize {
-		pcs.merge @current_group
-	}
-	party_members = Regexp.new pcs.to_a.join("|")
-	#Also check disk names against party members
-	GameObj.pcs.any? {|pc| pc.name !~ party_members} || GameObj.loot.any? {|obj| obj.noun == "disk" && obj.name !~ party_members}
+	if @new_room
+		pcs = Set.new @core_group
+		@group_mutex.synchronize {
+			pcs.merge @current_group
+		}
+		party_members = Regexp.new pcs.to_a.join("|")
+		#Also check disk names against party members
+		@poaching = GameObj.pcs.any? {|pc| pc.name !~ party_members} || GameObj.loot.any? {|obj| obj.noun == "disk" && obj.name !~ party_members}
+		@new_room = false
+	end
+	@poaching
 end
 
 def change_stance new_stance, force: true
@@ -696,6 +703,9 @@ group_hook = proc {|line|
 			@current_group.delete $~[:name]
 		}
 		nil
+	when /$Obvious exits:/
+		@new_room = true
+		line
 	else
 		line
 	end

--- a/rkill.lic
+++ b/rkill.lic
@@ -52,6 +52,7 @@ end
 	@current_group = get_current_group
 }
 
+@current_room_id = nil
 @new_room = true
 @poaching = true
 
@@ -127,7 +128,7 @@ end
 
 def cmd_gos
   sigils = [Spell[9707], Spell[9708], Spell[9710]]
-	
+
 	if Spell[9715].known?
 		sigils.push Spell[9715]
 	elsif Spell[9705].known?
@@ -697,18 +698,17 @@ group_hook = proc {|line|
 		@group_mutex.synchronize {
 			@current_group.push $~[:name]
 		}
-		nil
 	when /$(?<name>\w+) leaves (your|\w+'s) group.^/
 		@group_mutex.synchronize {
 			@current_group.delete $~[:name]
 		}
-		nil
 	when /$Obvious exits:/
-		@new_room = true
-		line
-	else
-		line
+		if Room.current.id != @current_room_id
+			@new_room = true
+			@current_room_id = Room.current.id
+		end
 	end
+	line
 }
 
 UpstreamHook.add @cmd_string, command_hook

--- a/rkill.lic
+++ b/rkill.lic
@@ -59,8 +59,9 @@ end
 @poach_targets = []
 
 def poaching?
-	#Test if someone in the room is unexpected, to avoid poaching
-	#Get minimal list of names to care about
+	#Test if someone in the room is unexpected, to avoid poaching.
+	#This respects room order, e.g. who was in the room first has hunting rights
+	#If that person(group) leaves, it is no longer considered poaching
 	if @new_room
 		@poach_targets = []
 		pcs = Set.new @core_group
@@ -68,21 +69,25 @@ def poaching?
 			pcs.merge @current_group
 		}
 		party_members = Regexp.new pcs.to_a.join("|")
-		#Also check disk names against party members
+		#Build list of PC's not recognized, and also check disk names against party members
 		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
 		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
-		@poach_targets = strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect{|disk|
+		#We need nouns for comparison
+		@poach_targets = strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
 			disk.name =~ /(?<name>\w+) disk/
-			$~[:name]}
+			$~[:name]
+		}
 		@poaching = !@poach_targets.empty?
 		@new_room = false
 	else
 		old_strangers = Set.new @poach_targets
 		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
 		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}
-		current_strangers = Set.new strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect{|disk|
+		current_strangers = Set.new strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
 			disk.name =~ /(?<name>\w+) disk/
-			$~[:name]}
+			$~[:name]
+		}
+		#Use set intersection as a fast way to tell if people left
 		if (current_strangers & old_strangers).empty?
 			@poaching = false
 		end

--- a/rkill.lic
+++ b/rkill.lic
@@ -55,6 +55,7 @@ end
 @current_room_id = nil
 @new_room = true
 @poaching = true
+@is_peer = false
 
 def poaching?
 	#Test if someone in the room is unexpected, to avoid poaching
@@ -702,8 +703,12 @@ group_hook = proc {|line|
 		@group_mutex.synchronize {
 			@current_group.delete $~[:name]
 		}
+	when /$The Symbol of Need begins to burn in your mind and an image appears before you of|$You peer (?:\w+) and see/
+		@is_peer = true
 	when /$Obvious exits:/
-		if Room.current.id != @current_room_id
+		if @is_peer
+			@is_peer = false
+		elsif Room.current.id != @current_room_id
 			@new_room = true
 			@current_room_id = Room.current.id
 		end

--- a/rkill.lic
+++ b/rkill.lic
@@ -68,7 +68,7 @@ def poaching?
 		@group_mutex.synchronize {
 			pcs.merge @current_group
 		}
-		party_members = Regexp.new pcs.to_a.join("|")
+		party_members = Regexp.new pcs.to_a.join("|"), Regexp::IGNORECASE
 		#Build list of PC's not recognized, and also check disk names against party members
 		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members}
 		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members}


### PR DESCRIPTION
This now watches for room changes (not symbol of need, look, or peer results) and considers poaching based on entering a room. This means that people entering the room will not cause rkill to pause in hunting based on people wandering by.