### PR TITLE
Tweak logic to ensure that commands don't run at inappropriate times

### DIFF
--- a/rkill.lic
+++ b/rkill.lic
@@ -476,6 +476,11 @@ def print_all_targets
 	}
 end
 
+def moving?
+	#Simple wrapper around logic to test if character is in motion
+	running?("go2") || running?("wander")
+end
+
 def execute_commands
 	#This defines the core hunting loop for all characters, executing a sequence of functions from a specified profile
 	target = nil
@@ -506,8 +511,8 @@ def execute_commands
 		end
 
 		deltaT = 0.0
-		#Not poaching, valid commands
-		if !dead? && !poaching? && cmds
+		#Not poaching, valid commands, not in motion
+		if !dead? && !moving? && !poaching? && cmds
 			#Only look for a target if we need it
 			if target && target.status =~ /dead|gone/
 				target = nil
@@ -527,7 +532,10 @@ def execute_commands
 			startTime = Time.now
 			#Executes each command in order, providing target if requested
 			cmds.each{ |cmd|
-				wait_while {running?("go2") || running?("wander")}
+				#This means we need to retarget and restart command loop
+				if moving? || poaching?
+					break
+				end
 				if cmd.parameters[0].include?(:target)
 					if target
 						cmd.call target

--- a/rkill.lic
+++ b/rkill.lic
@@ -66,7 +66,7 @@ def poaching?
 		@poach_targets = []
 	end
 	@room_mutex.synchronize {
-		if Room.current.id != @current_room_id
+		if @current_room_id && Room.current.id != @current_room_id
 			respond "Considering outdated room, assuming poaching until confirmed"
 			@poaching = true
 			return @poaching
@@ -751,8 +751,8 @@ group_hook = proc {|line|
 		}
 	when /^The Symbol of Need begins to burn in your mind and an image appears before you of|^You peer (?:\w+) and see/
 		@is_peer = true
-	when /Obvious (exits|paths):/
-		room_mutex.synchronize {
+	when /^Obvious (exits|paths):/
+		@room_mutex.synchronize {
 			if @is_peer
 				@is_peer = false
 			elsif @current_room_id && Room.current.id != @current_room_id
@@ -763,7 +763,7 @@ group_hook = proc {|line|
 	end
 	line
 }
-
+@current_room_id = Room.current.id
 UpstreamHook.add @cmd_string, command_hook
 DownstreamHook.add "#{script.name} update_group", group_hook
 before_dying {

--- a/rkill.lic
+++ b/rkill.lic
@@ -47,6 +47,7 @@ end
 
 @group_mutex = Mutex.new
 @vars_mutex = Mutex.new
+@room_mutex = Mutex.new
 
 @group_mutex.synchronize {
 	@current_group = get_current_group
@@ -64,6 +65,11 @@ def poaching?
 	if !@poach_targets
 		@poach_targets = []
 	end
+	@room_mutex.synchronize {
+		if Room.current.id != @current_room_id
+			return true
+		end
+	}
 	if @new_room
 		@poach_targets = []
 		pcs = Set.new @core_group
@@ -739,12 +745,14 @@ group_hook = proc {|line|
 	when /^The Symbol of Need begins to burn in your mind and an image appears before you of|^You peer (?:\w+) and see/
 		@is_peer = true
 	when /Obvious (exits|paths):/
-		if @is_peer
-			@is_peer = false
-		elsif @current_room_id && Room.current.id != @current_room_id
-			@new_room = true
-			@current_room_id = Room.current.id
-		end
+		room_mutex.synchronize {
+			if @is_peer
+				@is_peer = false
+			elsif @current_room_id && Room.current.id != @current_room_id
+				@new_room = true
+				@current_room_id = Room.current.id
+			end
+		}
 	end
 	line
 }

--- a/rkill.lic
+++ b/rkill.lic
@@ -53,7 +53,7 @@ end
 	@current_group = get_current_group
 }
 
-@current_room_id = nil
+@current_room_id = Room.current.id
 @new_room = true
 @poaching = true
 @is_peer = false
@@ -62,17 +62,8 @@ def poaching?
 	#Test if someone in the room is unexpected, to avoid poaching.
 	#This respects room order, e.g. who was in the room first has hunting rights
 	#If that person(group) leaves, it is no longer considered poaching
-	if !@poach_targets
-		@poach_targets = []
-	end
-	@room_mutex.synchronize {
-		if @current_room_id && Room.current.id != @current_room_id
-			respond "Considering outdated room, assuming poaching until confirmed"
-			@poaching = true
-			return @poaching
-		end
-	}
-	if @new_room
+	@poach_targets ||= []
+	if Room.current.id != @current_room_id
 		@poach_targets = []
 		pcs = Set.new @core_group
 		@group_mutex.synchronize {
@@ -83,13 +74,13 @@ def poaching?
 		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members} || []
 		disk_pcs = GameObj.loot.select {|obj| obj.noun == "disk" && obj.name !~ party_members} || []
 		#We need nouns for comparison
-		@poach_targets = strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
+		@poach_targets = Set.new(strange_pcs.collect {|pc| pc.noun} + disk_pcs.collect {|disk|
 			disk.name =~ /(?<name>\w+) disk/
 			$~[:name]
-		}
+		}).to_a
 		respond "Room #{Room.current.id} Poaching: #{@poach_targets}"
 		@poaching = !@poach_targets.empty?
-		@new_room = false
+		@current_room_id = Room.current.id
 	else
 		old_strangers = Set.new @poach_targets
 		strange_pcs = GameObj.pcs.select {|pc| pc.name !~ party_members} || []
@@ -749,21 +740,10 @@ group_hook = proc {|line|
 		@group_mutex.synchronize {
 			@current_group.delete $~[:name]
 		}
-	when /^The Symbol of Need begins to burn in your mind and an image appears before you of|^You peer (?:\w+) and see/
-		@is_peer = true
-	when /^Obvious (exits|paths):/
-		@room_mutex.synchronize {
-			if @is_peer
-				@is_peer = false
-			elsif @current_room_id && Room.current.id != @current_room_id
-				@new_room = true
-				@current_room_id = Room.current.id
-			end
-		}
 	end
 	line
 }
-@current_room_id = Room.current.id
+
 UpstreamHook.add @cmd_string, command_hook
 DownstreamHook.add "#{script.name} update_group", group_hook
 before_dying {

--- a/rkill.lic
+++ b/rkill.lic
@@ -10,6 +10,9 @@
 	Version: 2.0
 
 	changelog:
+		2.1:
+			Improved intelligence and reliability of poaching logic
+			Adding checks for common movement scripts to reduce targetting while running
 		2.0 (2017-09-23):
 			Added target priorities for focusing on certain enemies type before others
 			Improved group join/leave detection

--- a/rkill.lic
+++ b/rkill.lic
@@ -67,7 +67,8 @@ def poaching?
 	end
 	@room_mutex.synchronize {
 		if Room.current.id != @current_room_id
-			return true
+			@poaching = true
+			return @poaching
 		end
 	}
 	if @new_room
@@ -95,8 +96,9 @@ def poaching?
 			disk.name =~ /(?<name>\w+) disk/
 			$~[:name]
 		}
+		@poach_targets = (current_strangers & old_strangers).to_a
 		#Use set intersection as a fast way to tell if people left
-		if (current_strangers & old_strangers).empty?
+		if @poach_targets.empty?
 			@poaching = false
 		end
 	end

--- a/rkill.lic
+++ b/rkill.lic
@@ -67,6 +67,7 @@ def poaching?
 	end
 	@room_mutex.synchronize {
 		if Room.current.id != @current_room_id
+			respond "Considering outdated room, assuming poaching until confirmed"
 			@poaching = true
 			return @poaching
 		end
@@ -86,6 +87,7 @@ def poaching?
 			disk.name =~ /(?<name>\w+) disk/
 			$~[:name]
 		}
+		respond "Room #{Room.current.id} Poaching: #{@poach_targets}"
 		@poaching = !@poach_targets.empty?
 		@new_room = false
 	else
@@ -99,6 +101,9 @@ def poaching?
 		@poach_targets = (current_strangers & old_strangers).to_a
 		#Use set intersection as a fast way to tell if people left
 		if @poach_targets.empty?
+			if @poaching
+				respond "No longer poaching #{@poach_targets}"
+			end
 			@poaching = false
 		end
 	end


### PR DESCRIPTION
This helps eliminate the race condition between testing for poaching, and attacking. In theory, there's an inescapable race condition if a player is moving in response to some external stimulus, so they innermost test for moving and poaching passes, the creature and player move to the same room, and then the attack command fires.

Given that the window for this happening is likely under a millisecond, this should be fairly safe.

This also helps in that moving to a new room will reset the attack sequence, ensuring that the order of attacks listed is applied from the start when hunting.